### PR TITLE
Fix logging variable scope in displayStackSimple

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,9 +25,9 @@ const displayStackSimple = winston.format((info: any) => {
     return info
   }
 
-  let message = ''
-  let level = 1
   if (info instanceof Error) {
+    let message = ''
+    let level = 1
     const stacks = mergeStacks(info)
     message = addIndent(stacks.stack, level)
     if (stacks.cause) {
@@ -45,12 +45,14 @@ const displayStackSimple = winston.format((info: any) => {
         currentCause = currentCause.cause
       }
     }
+
+    return {
+      ...info,
+      message
+    }
   }
 
-  return{
-    ...info,
-    message
-  }
+  return info
 })
 
 const addIndent = (str: string, indentLevel: number): string => {


### PR DESCRIPTION
Move variable declarations inside the error handling block to improve scope management in the logging function. GC-4296